### PR TITLE
MG-362 option to enable/disable web server publish port

### DIFF
--- a/src/github.com/mageddo/dns-proxy-server/flags/flags.go
+++ b/src/github.com/mageddo/dns-proxy-server/flags/flags.go
@@ -19,6 +19,7 @@ var (
 		docker = start as docker service,
 		normal = start as normal service,
 		uninstall = uninstall the service from machine `)
+	publishServicePort = flag.Bool("service-publish-web-port", true, "Publish web port when running as service in docker mode")
 	Version = flag.Bool("version", false, "Current version")
 	Help = flag.Bool("help", false, "This message")
 )
@@ -34,6 +35,10 @@ func init(){
 		os.Exit(0)
 	}
 
+}
+
+func PublishServicePort() bool {
+	return *publishServicePort
 }
 
 func GetRawCurrentVersion() string {

--- a/src/github.com/mageddo/dns-proxy-server/service/docker.go
+++ b/src/github.com/mageddo/dns-proxy-server/service/docker.go
@@ -11,13 +11,21 @@ func NewDockerScript() *Script {
 
 	script := `'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ; ` +
 		`docker rm -f dns-proxy-server &> /dev/null ;` +
-		`docker run --hostname dns.mageddo --name dns-proxy-server -p %d:%d ` +
+		`docker run --hostname dns.mageddo --name dns-proxy-server %s ` +
 		`-v /opt/dns-proxy-server/conf:/app/conf ` +
 		`-v /var/run/docker.sock:/var/run/docker.sock ` +
 		`-v /etc/resolv.conf:/etc/resolv.conf ` +
 		`defreitas/dns-proxy-server:%s'`
 	script = strings.Replace(script, "/", "\\/", -1)
 	script = strings.Replace(script, "&", "\\&", -1)
-	script = fmt.Sprintf(script, conf.WebServerPort(), conf.WebServerPort(), flags.GetRawCurrentVersion())
+	script = fmt.Sprintf(script, getExposedPort(), flags.GetRawCurrentVersion())
 	return &Script{script}
+}
+
+func getExposedPort() string {
+	if flags.PublishServicePort()  {
+		return fmt.Sprintf("-p %d:%d", conf.WebServerPort(), conf.WebServerPort())
+	} else {
+		return ""
+	}
 }

--- a/src/github.com/mageddo/dns-proxy-server/service/service.go
+++ b/src/github.com/mageddo/dns-proxy-server/service/service.go
@@ -30,13 +30,13 @@ func NewService(ctx context.Context) *Service {
 
 func (sc *Service) Install() {
 
-	setupServiceFlag := *flags.SetupService
-	if len(setupServiceFlag) == 0 {
+	serviceMode := *flags.SetupService
+	if len(serviceMode) == 0 {
 		return
 	}
-	sc.logger.Infof("setupservice=%s, version=%s", setupServiceFlag, flags.GetRawCurrentVersion())
+	sc.logger.Infof("mode=%s, version=%s", serviceMode, flags.GetRawCurrentVersion())
 	var err error
-	switch setupServiceFlag {
+	switch serviceMode {
 	case "docker":
 		err = sc.SetupFor(DNS_PROXY_SERVER_PATH, DNS_PROXY_SERVER_SERVICE, NewDockerScript())
 	case "normal":


### PR DESCRIPTION
From version *2.0.4* when running Dns Proxy Server in service docker mode mode the web port is published, it can be a not desired behavior, so should be  optional