### PR TITLE
Static Build & No deps & Lighter Docker Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM debian:8
+FROM scratch
+
 ADD build/dns-proxy-server-linux-amd64*.tgz /app/
+
 WORKDIR /app
-VOLUME ["/var/run/docker.sock", "/var/run/docker.sock"]
-CMD ["bash", "-c", "/app/dns-proxy-server"]
+
+VOLUME ["/var/run/docker.sock"]
+
+ENTRYPOINT ["/app/dns-proxy-server"]

--- a/builder.bash
+++ b/builder.bash
@@ -146,7 +146,7 @@ case $1 in
 		export GOOS=$2
 		export GOARCH=$3
 		echo "> Compiling os=${GOOS}, arch=${GOARCH}"
-		go build -o $PWD/build/dns-proxy-server -ldflags "-X github.com/mageddo/dns-proxy-server/flags.version=$APP_VERSION"
+		CGO_ENABLED=0 go build -o $PWD/build/dns-proxy-server -ldflags "-s -w -X github.com/mageddo/dns-proxy-server/flags.version=$APP_VERSION"
 		TAR_FILE=dns-proxy-server-${GOOS}-${GOARCH}-${APP_VERSION}.tgz
 		cd $PWD/build/
 		tar --exclude=*.tgz -czf $TAR_FILE *


### PR DESCRIPTION
Related with Issue #143 

Compile App as static binary without dependencies to use a `scratch` image and shrink the new containers at minimum.

In my tests I have 10,5MB containers.

**NOTE:** I only can test AMD64 containers.