### PR TITLE
Resolving docker services using configured DPS domain.

### DIFF
--- a/events/docker/docker.go
+++ b/events/docker/docker.go
@@ -188,7 +188,7 @@ func getHostnameFromServiceName(inspect types.ContainerJSON) (string, error) {
 	const serviceNameLabelKey = "com.docker.compose.service"
 	if v, ok := inspect.Config.Labels[serviceNameLabelKey]; ok {
 		logging.Debugf("status=service-found, service=%s", v)
-		return fmt.Sprintf("%s.docker", v), nil
+		return fmt.Sprintf("%s.%s", v, conf.GetDpsDomain()), nil
 	}
 	return "", errors.New("service not found for container: " + inspect.Name)
 }

--- a/events/docker/docker_test.go
+++ b/events/docker/docker_test.go
@@ -73,6 +73,7 @@ func TestContainerNamesRegistryMustBeDisabledByDefault(t *testing.T){
 func TestMustGetHostnamesBasedOnMachineHostnameAndEnvironmentVariableAndContainerNameAndContainerServiceName(t *testing.T){
 
 	os.Setenv(env.MG_REGISTER_CONTAINER_NAMES, "1")
+	os.Setenv(env.MG_DOMAIN, "other.example.com")
 
 	// arrange
 	inspect := types.ContainerJSON{
@@ -85,13 +86,13 @@ func TestMustGetHostnamesBasedOnMachineHostnameAndEnvironmentVariableAndContaine
 		},
 	}
 	inspect.ContainerJSONBase = new(types.ContainerJSONBase)
-	inspect.Name = "/nginx-container"
+	inspect.Name = "/nginx-container_1"
 
 	// assert
 	hosts := getHostnames(inspect)
 
 	// act
-	assert.Equal(t, []string {"mageddo.com", "server2.mageddo.com", "server3.mageddo.com", "nginx-container.docker", "nginx-service.docker"}, hosts)
+	assert.Equal(t, []string {"mageddo.com", "server2.mageddo.com", "server3.mageddo.com", "nginx-container_1.other.example.com", "nginx-service.other.example.com"}, hosts)
 
 }
 


### PR DESCRIPTION
Currently to resolve docker service names, DPS always add ".docker" suffix to the docker service name, I guess because this is the default DPS domain.

This PR modifies this behavior to use the configured DPS domain instead of the default "docker" domain.

Tests have been modified to reflect the docker-compose behavior of adding "_1" to the container name created for a docker service.