### PR TITLE
Fix presence check of config setting "domain"

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -128,7 +128,7 @@ func GetDpsDomain() string {
 	if domain := os.Getenv(env.MG_DOMAIN); len(strings.TrimSpace(domain)) != 0 {
 		return domain
 	}
-	if conf, _ := getConf(); conf != nil &&  len(conf.HostMachineHostname) != 0 {
+	if conf, _ := getConf(); conf != nil &&  len(conf.Domain) != 0 {
 		return conf.Domain
 	}
 	return *flags.Domain


### PR DESCRIPTION
The existing check accidentally checked the length of the HostMachineHostname
instead of the Domain configuration setting to determine if the Domain setting
was present.