### PR TITLE
Use configured domain instead of 'docker' for service names

### DIFF
--- a/events/docker/docker.go
+++ b/events/docker/docker.go
@@ -188,7 +188,7 @@ func getHostnameFromServiceName(inspect types.ContainerJSON) (string, error) {
 	const serviceNameLabelKey = "com.docker.compose.service"
 	if v, ok := inspect.Config.Labels[serviceNameLabelKey]; ok {
 		logging.Debugf("status=service-found, service=%s", v)
-		return fmt.Sprintf("%s.docker", v), nil
+		return fmt.Sprintf("%s.%s", v, conf.GetDpsDomain()), nil
 	}
 	return "", errors.New("service not found for container: " + inspect.Name)
 }


### PR DESCRIPTION
Use the user's Domain setting for service names as well, not just for the
container name. Previously the service names always got the ".docker" domain
appended instead of what the user configured.