### PR TITLE
DPS 3 -  Minor fixes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,11 @@
+### 3.1.2-beta
+DPS 3 -  Minor fixes
+
+* Timed out remote servers responses are being cached, it cant happen, when its a timeout cant cache but when the record really dont exists, like AAAA for bookmarks.mageddo.com must cache.
+* Must read conf from dps binary path not the current os path where dps was called
+* Log level not being respected, at least no when running in native image binary
+* Removed quarkus splash logo
+
 ### 3.1.1-beta
 * Fixing reponse warning `;; Warning: query response not set`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.1.1-beta
+version=3.1.2-beta
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=2.16.0.Final
 quarkusPlatformGroupId=io.quarkus.platform

--- a/src/main/java/com/mageddo/dnsproxyserver/config/Configs.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/config/Configs.java
@@ -9,6 +9,7 @@ import com.mageddo.dnsproxyserver.config.entrypoint.LogLevel;
 import com.mageddo.dnsproxyserver.server.dns.IpAddr;
 import com.mageddo.dnsproxyserver.utils.Numbers;
 import com.mageddo.utils.Files;
+import com.mageddo.utils.Runtime;
 import com.mageddo.utils.Tests;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
@@ -115,8 +116,14 @@ public class Configs {
         .toAbsolutePath()
         ;
     }
-    return Paths
+    final var confRelativeToCurrDir = Paths
       .get(configFlag.getConfigPath())
+      .toAbsolutePath();
+    if (Files.exists(confRelativeToCurrDir)) {
+      return confRelativeToCurrDir;
+    }
+    return Runtime.getRunningDir()
+      .resolve(configFlag.getConfigPath())
       .toAbsolutePath();
   }
 

--- a/src/main/java/com/mageddo/dnsproxyserver/config/entrypoint/LogLevel.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/config/entrypoint/LogLevel.java
@@ -1,11 +1,30 @@
 package com.mageddo.dnsproxyserver.config.entrypoint;
 
+import org.apache.commons.lang3.StringUtils;
+
 public enum LogLevel {
-  FATAL,
   ERROR,
-  WARN,
+  WARNING("WARN"),
   INFO,
   DEBUG,
-  TRACE
   ;
+
+  private final String slf4jName;
+
+  LogLevel() {
+    this.slf4jName = null;
+  }
+
+  LogLevel(String slf4jName) {
+    this.slf4jName = slf4jName;
+  }
+
+  public String getSlf4jName() {
+    return StringUtils.firstNonBlank(this.slf4jName, this.name());
+  }
+
+  @Override
+  public String toString() {
+    return this.name();
+  }
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfig.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfig.java
@@ -16,6 +16,8 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 public class QuarkusConfig {
 
+  public static final String DPS_LOG_LEVEL_KEY = "quarkus.log.category.\"com.mageddo\".level";
+
   @Produces
   public RemoteResolvers remoteResolvers(Function<IpAddr, Resolver> resolverProvider) {
     final var servers = Configs
@@ -37,7 +39,7 @@ public class QuarkusConfig {
     System.setProperty("quarkus.http.port", String.valueOf(config.getWebServerPort()));
 
     if (config.getLogLevel() != null) {
-      System.setProperty("quarkus.log.category.\"com.mageddo\".level", config.getLogLevel().name());
+      System.setProperty(DPS_LOG_LEVEL_KEY, config.getLogLevel().getSlf4jName());
     }
 
     final var logFile = Configs.parseLogFile(config.getLogFile());

--- a/src/main/java/com/mageddo/dnsproxyserver/server/dns/solver/SolverRemote.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/server/dns/solver/SolverRemote.java
@@ -36,7 +36,10 @@ public class SolverRemote implements Solver {
         }
       } catch (IOException e) {
         if (e.getMessage().contains("Timed out while trying")) {
-          log.info("status=timedOut, req={}, msg={}", simplePrint(query), e.getMessage());
+          log.info(
+            "status=timedOut, req={}, msg={} class={}",
+            simplePrint(query), e.getMessage(), ClassUtils.getSimpleName(e)
+          );
           continue;
         }
         log.warn(

--- a/src/main/java/com/mageddo/utils/Files.java
+++ b/src/main/java/com/mageddo/utils/Files.java
@@ -14,4 +14,8 @@ public class Files {
       throw new UncheckedIOException(e);
     }
   }
+
+  public static boolean exists(Path p) {
+    return java.nio.file.Files.exists(p);
+  }
 }

--- a/src/main/java/com/mageddo/utils/Runtime.java
+++ b/src/main/java/com/mageddo/utils/Runtime.java
@@ -1,0 +1,72 @@
+package com.mageddo.utils;
+
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.ObjectUtils;
+import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.ProcessProperties;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Runtime {
+
+  /**
+   * @return the Jar path when running into a jar or null if not
+   */
+  @SneakyThrows
+  public static Path getRunningJar() {
+    final var jarPath = getRunningPath();
+    return isJar(jarPath) ? jarPath : null;
+  }
+
+  /**
+   * @return A directory when running on classes on directory
+   * or a jar when running into a jar
+   */
+  @SneakyThrows
+  public static Path getRunningPath() {
+    final var url = getRunningURL();
+    return Paths.get(url.toURI());
+  }
+
+  public static Path getRunningDir() {
+    if (ImageInfo.inImageRuntimeCode()) {
+      return Paths.get(ProcessProperties.getExecutableName()).getParent();
+    }
+    final var path = getRunningPath();
+    if (isJar(path)) {
+      return path.getParent();
+    }
+    return path;
+  }
+
+  public static boolean runningOnJar() {
+    return isJar(getRunningPath());
+  }
+
+  public static boolean isJar(Path jarPath) {
+    return jarPath.toString()
+      .endsWith(".jar");
+  }
+
+  private static URL getRunningURL() {
+    return ObjectUtils.firstNonNull(
+      getUrlWhenNotJar(),
+      getUrlWhenJarAndNotJar()
+    );
+  }
+
+  private static URL getUrlWhenNotJar() {
+    return Runtime.class
+      .getClassLoader()
+      .getResource(".");
+  }
+
+  private static URL getUrlWhenJarAndNotJar() {
+    return Runtime.class
+      .getProtectionDomain()
+      .getCodeSource()
+      .getLocation();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 version=${version}
 
+quarkus.banner.enabled=false
+
 quarkus.http.port=5380
 
 # Logs

--- a/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
@@ -1,5 +1,6 @@
 package com.mageddo.dnsproxyserver.config;
 
+import com.mageddo.dnsproxyserver.templates.ConfigFlagTemplates;
 import com.mageddo.dnsproxyserver.templates.EnvTemplates;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static com.mageddo.utils.TestUtils.readAndSortJsonExcluding;
 import static com.mageddo.utils.TestUtils.readAsStream;
@@ -89,5 +91,33 @@ class ConfigsTest {
       firstEntry.getId() < currentNanoTime,
       String.format("id=%s, currentTimeInMillis=%s", firstEntry.getId(), currentNanoTime)
     );
+  }
+
+  @Test
+  void mustBuildConfPathRelativeToWorkDir(){
+    // arrange
+    final var flags = ConfigFlagTemplates.defaultWithConfigPath(Paths.get("conf/config.json"));
+    final var currentPath = Paths.get("/tmp/");
+
+    // act
+    final var path = Configs.buildConfigPath(flags, currentPath);
+
+    // assert
+    assertEquals("/tmp/conf/config.json", path.toString());
+  }
+
+  @Test
+  void mustBuildConfPathRelativeToBinaryRunningPathWhenWorkDirIsNotSet(){
+    // arrange
+    final var flags = ConfigFlagTemplates.defaultWithConfigPath(Paths.get("conf/config.json"));
+    final Path currentPath = null;
+
+    // act
+    final var path = Configs.buildConfigPath(flags, currentPath);
+
+    // assert
+    assertEquals("/home/typer/dev/projects/dns-proxy-server/conf/config.json", path.toString());
+
+
   }
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
@@ -1,5 +1,6 @@
 package com.mageddo.dnsproxyserver.config;
 
+import com.mageddo.dnsproxyserver.config.entrypoint.LogLevel;
 import com.mageddo.dnsproxyserver.templates.ConfigFlagTemplates;
 import com.mageddo.dnsproxyserver.templates.EnvTemplates;
 import lombok.SneakyThrows;
@@ -106,4 +107,15 @@ class ConfigsTest {
     assertEquals("/tmp/conf/config.json", path.toString());
   }
 
+  @Test
+  void mustParseLowerCaseLogLevel(){
+    // arrange
+    final var args = new String[]{"--log-level", "warning"};
+
+    // act
+    final var config = Configs.buildAndRegister(args);
+
+    // assert
+    assertEquals(LogLevel.WARNING, config.getLogLevel());
+  }
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/config/ConfigsTest.java
@@ -106,18 +106,4 @@ class ConfigsTest {
     assertEquals("/tmp/conf/config.json", path.toString());
   }
 
-  @Test
-  void mustBuildConfPathRelativeToBinaryRunningPathWhenWorkDirIsNotSet(){
-    // arrange
-    final var flags = ConfigFlagTemplates.defaultWithConfigPath(Paths.get("conf/config.json"));
-    final Path currentPath = null;
-
-    // act
-    final var path = Configs.buildConfigPath(flags, currentPath);
-
-    // assert
-    assertEquals("/home/typer/dev/projects/dns-proxy-server/conf/config.json", path.toString());
-
-
-  }
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfigTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfigTest.java
@@ -1,0 +1,21 @@
+package com.mageddo.dnsproxyserver.quarkus;
+
+import com.mageddo.dnsproxyserver.templates.ConfigTemplates;
+import org.junit.jupiter.api.Test;
+
+import static com.mageddo.dnsproxyserver.quarkus.QuarkusConfig.DPS_LOG_LEVEL_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QuarkusConfigTest {
+  @Test
+  void mustLogLevelInSl4jConvetion(){
+    // arrange
+    final var config = ConfigTemplates.withoutId();
+
+    // act
+    QuarkusConfig.setup(config);
+
+    // assert
+    assertEquals(System.getProperty(DPS_LOG_LEVEL_KEY), "WARN");
+  }
+}

--- a/src/test/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfigTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfigTest.java
@@ -18,4 +18,6 @@ class QuarkusConfigTest {
     // assert
     assertEquals(System.getProperty(DPS_LOG_LEVEL_KEY), "WARN");
   }
+
+
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/server/dns/solver/SolversCacheTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/server/dns/solver/SolversCacheTest.java
@@ -9,6 +9,7 @@ import org.xbill.DNS.Flags;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +34,19 @@ class SolversCacheTest {
     assertEquals(req.getHeader().getID(), res.getHeader().getID());
     assertTrue(header.getFlag(Flags.QR));
 
+  }
+
+  @Test
+  void cantCacheWhenDelegateSolverHasNoAnswer(){
+    // arrange
+    final var query = MessageTemplates.acmeAQuery();
+
+    // act
+    final var res = this.cache.handle(query, message -> null);
+
+    // assert
+    assertNull(res);
+    assertEquals(0, this.cache.getSize());
   }
 
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigFlagTemplates.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigFlagTemplates.java
@@ -1,0 +1,15 @@
+package com.mageddo.dnsproxyserver.templates;
+
+import com.mageddo.dnsproxyserver.config.entrypoint.ConfigFlag;
+
+import java.nio.file.Path;
+
+public class ConfigFlagTemplates {
+  public static ConfigFlag build() {
+    return ConfigFlag.parse(new String[]{});
+  }
+
+  public static ConfigFlag defaultWithConfigPath(Path path) {
+    return ConfigFlag.parse(new String[]{"--conf-path", path.toString()});
+  }
+}

--- a/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigTemplates.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigTemplates.java
@@ -1,6 +1,7 @@
 package com.mageddo.dnsproxyserver.templates;
 
 import com.mageddo.dnsproxyserver.config.Config;
+import com.mageddo.dnsproxyserver.config.entrypoint.LogLevel;
 
 import java.nio.file.Paths;
 
@@ -19,6 +20,8 @@ public class ConfigTemplates {
       .version("3.0.0")
       .dnsServerPort(53)
       .domain("com")
+      .logLevel(LogLevel.WARNING)
+      .resolvConfPath(Paths.get("/etc/resolv.conf"))
       .build();
   }
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigTemplates.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/templates/ConfigTemplates.java
@@ -7,6 +7,11 @@ import java.nio.file.Paths;
 
 public class ConfigTemplates {
   public static Config withoutId() {
+    return defaultBuilder()
+      .build();
+  }
+
+  private static Config.ConfigBuilder defaultBuilder() {
     return Config
       .builder()
       .logFile("/tmp/dps.log")
@@ -21,7 +26,8 @@ public class ConfigTemplates {
       .dnsServerPort(53)
       .domain("com")
       .logLevel(LogLevel.WARNING)
-      .resolvConfPath(Paths.get("/etc/resolv.conf"))
-      .build();
+      .resolvConfPath(Paths.get("/etc/resolv.conf"));
   }
+
+
 }


### PR DESCRIPTION
* [x] Timed out remote servers responses are being cached, it cant happen, when its a timeout cant cache but when the record really dont exists, like AAAA for bookmarks.mageddo.com must cache.
* [x] Must read conf from dps binary path not the current os path where dps was called
* [x] Log level not being respected, at least no when running in native image binary
* [x] Remove quarkus splash logo


Partially fixes https://github.com/mageddo/dns-proxy-server/issues/267