### PR TITLE
DPS 3 - Bind UDP server to all available interfaces

### DIFF
--- a/src/main/java/com/mageddo/dnsproxyserver/net/Networks.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/net/Networks.java
@@ -3,21 +3,33 @@ package com.mageddo.dnsproxyserver.net;
 import com.mageddo.dnsproxyserver.server.dns.IP;
 import lombok.SneakyThrows;
 
+import java.io.UncheckedIOException;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 public class Networks {
 
   @SneakyThrows
   public static IP findCurrentMachineIP() {
-    return NetworkInterface
-      .networkInterfaces()
-      .flatMap(NetworkInterface::inetAddresses)
-      .filter(it -> it.getAddress().length == IP.BYTES)
-      .map(it -> IP.of(it.getHostAddress()))
-      .sorted(Comparator.comparing(it -> it.raw().startsWith("127") ? Integer.MAX_VALUE : 0))
+    return findMachineIps()
       .findFirst()
       .orElse(null);
   }
 
+  public static Stream<IP> findMachineIps() {
+    try {
+      return NetworkInterface
+        .networkInterfaces()
+        .flatMap(NetworkInterface::inetAddresses)
+        .filter(it -> it.getAddress().length == IP.BYTES)
+        .filter(it -> !it.isLoopbackAddress())
+        .map(it -> IP.of(it.getHostAddress()))
+        .sorted(Comparator.comparing(it -> it.raw().startsWith("127") ? Integer.MAX_VALUE : 0))
+        ;
+    } catch (SocketException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfig.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/quarkus/QuarkusConfig.java
@@ -30,7 +30,7 @@ public class QuarkusConfig {
   public Function<IpAddr, Resolver> getResolverProvider() {
     return it -> {
       final var resolver = new SimpleResolver(InetAddresses.toSocketAddress(it.getRawIP(), it.getPortOrDef(53)));
-      resolver.setTimeout(Duration.ofMillis(250));
+      resolver.setTimeout(Duration.ofMillis(300));
       return resolver;
     };
   }

--- a/src/main/java/com/mageddo/dnsproxyserver/server/dns/ServerStarter.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/server/dns/ServerStarter.java
@@ -36,7 +36,7 @@ public class ServerStarter {
       Config.findDnsServerProtocol(),
       this.solvers
     );
-    log.info("status=startingDnsServer, port={}", port);
+    log.trace("status=startingDnsServer, port={}", port);
     return this;
   }
 

--- a/src/main/java/com/mageddo/dnsproxyserver/server/dns/SimpleServer.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/server/dns/SimpleServer.java
@@ -17,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor(onConstructor = @__({@Inject}))
 public class SimpleServer {
 
-  private final UDPServer udpServer;
+  private final UDPServerPool udpServerPool;
   private final TCPServer tcpServer;
   private final RequestHandler requestHandler;
 
@@ -31,12 +31,12 @@ public class SimpleServer {
   void start0(int port, Protocol protocol) {
     final var tcpHandler = new TCPHandler(this.requestHandler);
     switch (protocol) {
-      case UDP -> this.udpServer.start(port);
+      case UDP -> this.udpServerPool.start(port);
       case TCP -> {
         this.tcpServer.start(port, null, tcpHandler);
       }
       default -> {
-        this.udpServer.start(port);
+        this.udpServerPool.start(port);
         this.tcpServer.start(port, null, tcpHandler);
       }
     }

--- a/src/main/java/com/mageddo/dnsproxyserver/server/dns/UDPServerPool.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/server/dns/UDPServerPool.java
@@ -1,0 +1,36 @@
+package com.mageddo.dnsproxyserver.server.dns;
+
+import com.mageddo.dnsproxyserver.net.Networks;
+import com.mageddo.dnsproxyserver.utils.Ips;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class UDPServerPool {
+
+  private final RequestHandler requestHandler;
+  private List<UDPServer> servers = new ArrayList<>();
+
+  public void start(int port) {
+    this.servers = Networks
+      .findMachineIps()
+      .map(it -> new UDPServer(Ips.toSocketAddress(it.raw(), port), this.requestHandler))
+      .peek(UDPServer::start)
+      .toList();
+    final var addresses = this.servers
+      .stream()
+      .map(UDPServer::getAddress)
+      .map(SocketAddress::toString)
+      .collect(Collectors.joining(", "));
+    log.info("Starting UDP server, addresses={}", addresses);
+  }
+}

--- a/src/main/java/com/mageddo/dnsproxyserver/utils/Ips.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/utils/Ips.java
@@ -6,6 +6,8 @@ import org.apache.commons.lang3.Validate;
 
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
 
 public class Ips {
@@ -36,5 +38,9 @@ public class Ips {
 
   public static InetAddress toAddress(IP ip) {
     return toAddress(ip.raw());
+  }
+
+  public static SocketAddress toSocketAddress(String ip, int port) {
+    return new InetSocketAddress(Ips.toAddress(ip), port);
   }
 }


### PR DESCRIPTION
I was using WILDCARD to create the DatagramSocket `new DatagramSocket(port)` but was getting issues, by some reason the dns clients like nslookup wasn't able the get the responses when querying using a virtual network interface like docker, when querying using the real interfaces or 127.0.0.1 it worked.

Solution was to start one UDP server for every interface this way all worked