### PR TITLE
Filter nonNull objects in ContainerSolvingService findBestMatch

### DIFF
--- a/src/main/java/com/mageddo/dnsproxyserver/docker/ContainerSolvingService.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/docker/ContainerSolvingService.java
@@ -47,6 +47,7 @@ public class ContainerSolvingService {
     final var foundIp = matchedContainers
       .stream()
       .map(it -> this.findBestIpMatch(it, host.getVersion()))
+      .filter(Objects::nonNull)
       .findFirst()
       .orElse(null);
     final var hostnameMatched = !matchedContainers.isEmpty();


### PR DESCRIPTION
Might fix this issue (but can't test locally at the moment):

16:17:22.552 [Thread-10      ] WAR c.m.d.server.dns.RequestHandlerDefault            l=93   m=solve0                          status=solverFailed, currentSolverTime=195, totalTime=195, solver=SolverDocker, query=query=AAAA:somecontainer.sometld, eClass=NullPointerException, msg=null
java.lang.NullPointerException: null
	at java.base@19.0.2/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base@19.0.2/java.util.Optional.of(Optional.java:113)
	at java.base@19.0.2/java.util.stream.FindOps$FindSink$OfRef.get(FindOps.java:194)
	at java.base@19.0.2/java.util.stream.FindOps$FindSink$OfRef.get(FindOps.java:191)
	at java.base@19.0.2/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base@19.0.2/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base@19.0.2/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at com.mageddo.dnsproxyserver.docker.ContainerSolvingService.findBestMatch(ContainerSolvingService.java:50)
	at com.mageddo.dnsproxyserver.server.dns.solver.SolverDocker.lambda$handle$0(SolverDocker.java:40)
	at com.mageddo.dnsproxyserver.server.dns.solver.HostnameMatcher.match(HostnameMatcher.java:22)
	at com.mageddo.dnsproxyserver.server.dns.solver.SolverDocker.handle(SolverDocker.java:39)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solve0(RequestHandlerDefault.java:75)
	at com.mageddo.dnsproxyserver.server.dns.solver.SolverCache.lambda$handleRes$0(SolverCache.java:38)
	at com.mageddo.commons.caching.LruTTLCache.lambda$computeIfAbsentWithTTL$1(LruTTLCache.java:94)
	at java.base@19.0.2/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1955)
	at com.mageddo.commons.caching.LruTTLCache.lambda$computeIfAbsentWithTTL$2(LruTTLCache.java:88)
	at java.base@19.0.2/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at com.mageddo.commons.caching.LruTTLCache.computeIfAbsentWithTTL(LruTTLCache.java:86)
	at com.mageddo.dnsproxyserver.server.dns.solver.SolverCache.handleRes(SolverCache.java:36)
	at com.mageddo.dnsproxyserver.server.dns.solver.SolverCache.handle(SolverCache.java:31)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solve(RequestHandlerDefault.java:51)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.handle(RequestHandlerDefault.java:42)
	at com.mageddo.dnsproxyserver.server.dns.UDPServer.handle(UDPServer.java:54)
	at com.mageddo.dnsproxyserver.server.dns.UDPServer.lambda$start0$0(UDPServer.java:42)
	at java.base@19.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)
	at java.base@19.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base@19.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@19.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base@19.0.2/java.lang.Thread.run(Thread.java:1589)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:775)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:203)
