### PR TITLE
Bump Docker client API to fix compatibility with Docker version 25

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.16.1
+* Bump Docker client API to fix compatibility with Docker version 25 #432
+
 ## 3.16
 * Circuit Breaker for Remote DNS Servers #415
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ dependencies {
   implementation('org.rauschig:jarchivelib:1.2.0')
   implementation('dev.failsafe:failsafe:3.3.1')
 
-  implementation('com.github.docker-java:docker-java-core:3.2.14')
-  implementation('com.github.docker-java:docker-java-transport-httpclient5:3.2.14')
+  implementation('com.github.docker-java:docker-java-core:3.3.4')
+  implementation('com.github.docker-java:docker-java-transport-httpclient5:3.3.4')
 
   implementation('info.picocli:picocli:4.7.1')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.16.0-snapshot
+version=3.16.1-snapshot

--- a/src/main/java/com/mageddo/dnsproxyserver/quarkus/DockerConfig.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/quarkus/DockerConfig.java
@@ -23,7 +23,7 @@ public class DockerConfig {
     final var config = DefaultDockerClientConfig.createDefaultConfigBuilder()
       .withDockerHost(Objects.mapOrNull(dockerHost, URI::toString))
       .withDockerTlsVerify(false)
-      .withApiVersion(RemoteApiVersion.VERSION_1_21)
+      .withApiVersion(RemoteApiVersion.VERSION_1_24)
 //      .withDockerCertPath("/home/user/.docker")
 //      .withRegistryUsername(registryUser)
 //      .withRegistryPassword(registryPass)


### PR DESCRIPTION
Fixes #431 

[Tests are passing](https://github.com/ThisIsQasim/dns-proxy-server/actions/runs/7669451043)