### PR TITLE
#474 Fixing error when fallback to host machine IP 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.19.5
+* #474: Fixing errors log occurs when fallback to host machine IP.
+
 ## 3.19.4
 * #476: Fixing invalid IP parsing usecase
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.19.4-snapshot
+version=3.19.5-snapshot

--- a/src/main/java/com/mageddo/dnsproxyserver/docker/domain/Drivers.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/docker/domain/Drivers.java
@@ -3,4 +3,5 @@ package com.mageddo.dnsproxyserver.docker.domain;
 public class Drivers {
   public static final String BRIDGE = "bridge";
   public static final String OVERLAY = "overlay";
+  public static final String HOST = "host";
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/Network.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/Network.java
@@ -34,6 +34,10 @@ public class Network {
       .orElse(null);
   }
 
+  public boolean hasAnyGateway() {
+    return !this.gateways.isEmpty();
+  }
+
   public enum Name {
 
     DPS,

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/Network.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/Network.java
@@ -38,6 +38,13 @@ public class Network {
     return !this.gateways.isEmpty();
   }
 
+  public boolean hasAnyGatewayWith(IP.Version version) {
+    return this.gateways
+      .stream()
+      .anyMatch(it -> Objects.equals(it.version(), version))
+      ;
+  }
+
   public enum Name {
 
     DPS,

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DockerDAODefault.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DockerDAODefault.java
@@ -36,9 +36,8 @@ public class DockerDAODefault implements DockerDAO {
   }
 
   Network findBestNetwork(IP.Version version) {
-    final var network = this.findNetworks()
+    final var network = this.findNetworksWithIp(version)
       .stream()
-      .filter(it -> java.util.Objects.equals(it.isIpv6Active(), version.isIpv6()))
       .min(NetworkComparator::compare)
       .orElse(null);
     log.debug("status=bestNetwork, network={}", network);
@@ -50,6 +49,13 @@ public class DockerDAODefault implements DockerDAO {
       .exec()
       .stream()
       .map(NetworkMapper::of)
+      .toList();
+  }
+
+  List<Network> findNetworksWithIp(IP.Version version) {
+    return this.findNetworks()
+      .stream()
+      .filter(it -> it.hasAnyGatewayWith(version))
       .toList();
   }
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
@@ -36,15 +36,18 @@ public class NetworkMapper {
     if (network == null) {
       return null;
     }
-    return network
-      .getIpam()
-      .getConfig()
-      .stream()
-      .map(com.github.dockerjava.api.model.Network.Ipam.Config::getGateway)
-      .map(IP::of)
-      .filter(it -> it.version() == version)
-      .findFirst()
-      .orElse(null)
-      ;
+    final var ipam = network.getIpam();
+    if (ipam != null && ipam.getConfig() != null) {
+      return ipam
+        .getConfig()
+        .stream()
+        .map(com.github.dockerjava.api.model.Network.Ipam.Config::getGateway)
+        .map(IP::of)
+        .filter(it -> it.version() == version)
+        .findFirst()
+        .orElse(null)
+        ;
+    }
+    return null;
   }
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
@@ -2,13 +2,16 @@ package com.mageddo.dnsproxyserver.solver.docker.dataprovider.mapper;
 
 import com.mageddo.dnsproxyserver.solver.docker.Network;
 import com.mageddo.net.IP;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Objects;
 import java.util.stream.Stream;
 
+@Slf4j
 public class NetworkMapper {
 
   public static Network of(com.github.dockerjava.api.model.Network n) {
+    log.debug("status=mapping, networkName={}", n.getName());
     return Network.builder()
       .name(n.getName())
       .driver(n.getDriver())

--- a/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DockerDAODefaultTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DockerDAODefaultTest.java
@@ -1,6 +1,5 @@
 package com.mageddo.dnsproxyserver.solver.docker.dataprovider;
 
-import com.mageddo.dnsproxyserver.solver.docker.dataprovider.DockerDAODefault;
 import com.mageddo.net.IP;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,5 +62,29 @@ class DockerDAODefaultTest {
     assertEquals(IP.of("2001:db8:1::1"), ip);
 
   }
+
+  @Test
+  void mustIgnoreNetworksWithoutIP() {
+
+    // arrange
+    final var version = IP.Version.IPV4;
+    final var networks = List.of(
+      NetworkTemplates.withHostDriverWithoutIps(),
+      NetworkTemplates.withBridgeIpv4AndIpv6Network()
+    );
+
+    doReturn(networks)
+      .when(this.dockerDAO)
+      .findNetworks();
+
+    // act
+    final var ip = this.dockerDAO.findHostMachineIp(version);
+
+    // assert
+    assertNotNull(ip);
+    assertEquals(IP.of("172.21.0.1"), ip);
+
+  }
+
 
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
@@ -1,17 +1,18 @@
 package com.mageddo.dnsproxyserver.solver.docker.dataprovider.mapper;
 
 import com.mageddo.dnsproxyserver.docker.domain.Drivers;
-import com.mageddo.dnsproxyserver.solver.docker.dataprovider.mapper.NetworkMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import testing.templates.docker.NetworkTemplates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static testing.templates.docker.NetworkTemplates.buildBridgeIpv4AndIpv6Network;
 import static testing.templates.docker.NetworkTemplates.buildBridgeIpv4OnlyNetwork;
+import static testing.templates.docker.NetworkTemplates.buildHostNetworkWithNoIpam;
 
 @ExtendWith(MockitoExtension.class)
 class NetworkMapperTest {
@@ -58,6 +59,21 @@ class NetworkMapperTest {
     // assert
     assertNotNull(network);
     assertEquals("[172.21.0.1]", network.getGateways().toString());
+  }
+
+  @Test
+  void mustLeadWhenNoIpamConfigIsAvailable(){
+
+    // arrange
+    final var dockerNetwork = buildHostNetworkWithNoIpam();
+
+    // act
+    final var network = NetworkMapper.of(dockerNetwork);
+
+    // assert
+    assertNotNull(network);
+    assertFalse(network.hasAnyGateway());
+    assertEquals("[]", network.getGateways().toString());
   }
 
 }

--- a/src/test/java/testing/templates/docker/NetworkTemplates.java
+++ b/src/test/java/testing/templates/docker/NetworkTemplates.java
@@ -40,4 +40,8 @@ public class NetworkTemplates {
     return JsonUtils.readValue(readString("/templates/docker/network/002.json"), Network.class);
   }
 
+  public static Network buildHostNetworkWithNoIpam() {
+    return JsonUtils.readValue(readString("/templates/docker/network/003.json"), Network.class);
+  }
+
 }

--- a/src/test/java/testing/templates/server/dns/solver/docker/NetworkTemplates.java
+++ b/src/test/java/testing/templates/server/dns/solver/docker/NetworkTemplates.java
@@ -45,6 +45,16 @@ public class NetworkTemplates {
       ;
   }
 
+  public static Network withHostDriverWithoutIps() {
+    return builder()
+      .name("host")
+      .driver(Drivers.HOST)
+      .gateways(Collections.emptyList())
+      .ipv6Active(false)
+      .build()
+      ;
+  }
+
   static Network.NetworkBuilder builder() {
     return Network.builder()
       .gateways(Collections.emptyList())

--- a/src/test/resources/templates/docker/network/003.json
+++ b/src/test/resources/templates/docker/network/003.json
@@ -1,0 +1,23 @@
+{
+  "Name": "host",
+  "Id": "c0e229b3e0dfc6265fe508026ad5e71199abac6f4dda240d9dd53c2192b3e5ed",
+  "Created": "2022-03-24T15:56:28.398813695Z",
+  "Scope": "local",
+  "Driver": "host",
+  "EnableIPv6": false,
+  "IPAM": {
+    "Driver": "default",
+    "Options": null,
+    "Config": null
+  },
+  "Internal": false,
+  "Attachable": false,
+  "Ingress": false,
+  "ConfigFrom": {
+    "Network": ""
+  },
+  "ConfigOnly": false,
+  "Containers": {},
+  "Options": {},
+  "Labels": {}
+}


### PR DESCRIPTION
Fixing error when fallback to host machine IP, Network mapper fails when the mapped networks hasn't  an IPAM config, it has more chances to happen on IPV6 query solving.

Relates to #474 .