### PR TITLE
#427: Hotfix for ipv6 represented as subnet usecase

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.19.7
+* #427, #481: Hotfix for ipv6 address represented with subnet mask
+
 ## 3.19.6
 * #465: DnsConfigurators: checking docker connection
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.19.6-snapshot
+version=3.19.7-snapshot

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapper.java
@@ -3,12 +3,16 @@ package com.mageddo.dnsproxyserver.solver.docker.dataprovider.mapper;
 import com.mageddo.dnsproxyserver.solver.docker.Network;
 import com.mageddo.net.IP;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
 import java.util.stream.Stream;
 
 @Slf4j
 public class NetworkMapper {
+
+  public static final int CHAR_NOT_FOUND = -1;
+  public static final char SUBNET_MASK_SEPARATOR = '/';
 
   public static Network of(com.github.dockerjava.api.model.Network n) {
     log.debug("status=mapping, networkName={}", n.getName());
@@ -42,6 +46,7 @@ public class NetworkMapper {
         .getConfig()
         .stream()
         .map(com.github.dockerjava.api.model.Network.Ipam.Config::getGateway)
+        .map(NetworkMapper::extractIpIfNeedledWhenGatewayIsSubnet)
         .map(IP::of)
         .filter(it -> it.version() == version)
         .findFirst()
@@ -49,5 +54,13 @@ public class NetworkMapper {
         ;
     }
     return null;
+  }
+
+  private static String extractIpIfNeedledWhenGatewayIsSubnet(String str) {
+    final int index = str.indexOf(SUBNET_MASK_SEPARATOR);
+    if (index == CHAR_NOT_FOUND) {
+      return str;
+    }
+    return StringUtils.substring(str, 0, index);
   }
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
@@ -76,4 +76,23 @@ class NetworkMapperTest {
     assertEquals("[]", network.getGateways().toString());
   }
 
+
+  /**
+   * see https://github.com/mageddo/dns-proxy-server/issues/427
+   */
+  @Test
+  void mustExtractIpWhenASubnetIsSetAtIpv6TheGatewayIp(){
+
+    // arrange
+    final var dockerNetwork = NetworkTemplates.buildBridgeWithSubnetIPAtGatewayProp();
+
+    // act
+    final var network = NetworkMapper.of(dockerNetwork);
+
+    // assert
+    assertNotNull(network);
+    assertTrue(network.hasAnyGateway());
+    assertEquals("[172.19.0.1, fddb:21e4:36d4:2:0:0:0:1]", network.getGateways().toString());
+  }
+
 }

--- a/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/mapper/NetworkMapperTest.java
@@ -78,7 +78,7 @@ class NetworkMapperTest {
 
 
   /**
-   * see https://github.com/mageddo/dns-proxy-server/issues/427
+   * see https://github.com/mageddo/dns-proxy-server/issues/481
    */
   @Test
   void mustExtractIpWhenASubnetIsSetAtIpv6TheGatewayIp(){

--- a/src/test/java/testing/templates/docker/NetworkTemplates.java
+++ b/src/test/java/testing/templates/docker/NetworkTemplates.java
@@ -44,4 +44,7 @@ public class NetworkTemplates {
     return JsonUtils.readValue(readString("/templates/docker/network/003.json"), Network.class);
   }
 
+  public static Network buildBridgeWithSubnetIPAtGatewayProp() {
+    return JsonUtils.readValue(readString("/templates/docker/network/004.json"), Network.class);
+  }
 }

--- a/src/test/resources/templates/docker/network/004.json
+++ b/src/test/resources/templates/docker/network/004.json
@@ -1,0 +1,40 @@
+{
+  "Name": "redis",
+  "Id": "c9334be3920e50d406752892eda45caa1d64f73f6cecca736750147fbbc89ae6",
+  "Created": "2024-06-19T18:21:46.209161659Z",
+  "Scope": "local",
+  "Driver": "bridge",
+  "EnableIPv6": true,
+  "IPAM": {
+    "Driver": "default",
+    "Options": null,
+    "Config": [
+      {
+        "Subnet": "172.19.0.0/16",
+        "Gateway": "172.19.0.1"
+      },
+      {
+        "Subnet": "fddb:21e4:36d4:2::/64",
+        "Gateway": "fddb:21e4:36d4:2::1/64"
+      }
+    ]
+  },
+  "Internal": false,
+  "Attachable": false,
+  "Ingress": false,
+  "ConfigFrom": {
+    "Network": ""
+  },
+  "ConfigOnly": false,
+  "Containers": {
+    "745e201849ac8ee33999821c801c47e5258775fce33b0c4e66c1a054e530cbaf": {
+      "Name": "redis",
+      "EndpointID": "27d555e7ee34e4cfdd61681b37018bbe0afe8ff33d309a7ae069e743b7751bbe",
+      "MacAddress": "02:42:ac:13:00:02",
+      "IPv4Address": "172.19.0.2/16",
+      "IPv6Address": "fddb:21e4:36d4:2::2/64"
+    }
+  },
+  "Options": {},
+  "Labels": {}
+}


### PR DESCRIPTION
As reported at #427, For a unidentified reason, sometimes network api  responds an IPV6 with a subnet mask instead of a plain IP which is the expected behavior, a hotfix for that was made to extract the IP from this string when it happens, it only happens with ipv6 addresses.

Expected address

```
"Gateway": "fddb:21e4:36d4:2::1"
```

Actual address


```
"Gateway": "fddb:21e4:36d4:2::1/64"
```