### PR TITLE
#435: Fixed Jar release which was broken when upgraded to java 21 at `3.22.0`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.22.1 
+* #502: Fixed Jar release which was broken when upgraded to java 21 at `3.22.0`
+
 ## 3.22.0 
 * #473: Qemu upgrade
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
   annotationProcessor("com.google.dagger:dagger-compiler:2.45")
   implementation("com.google.dagger:dagger:2.45")
 
+  implementation('org.graalvm.sdk:graal-sdk:24.0.1')
+
   implementation('jakarta.enterprise:jakarta.enterprise.cdi-api:2.0.2')
   implementation('jakarta.ws.rs:jakarta.ws.rs-api:2.1.6')
   implementation('com.mageddo.commons:commons-lang:0.1.16')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.22.0-snapshot
+version=3.22.1-snapshot


### PR DESCRIPTION
Fixed Jar release which was broken when upgraded to java 21.