### PR TITLE
Build Aarch64 image with page size of 64k to Increase Compatibility

### DIFF
--- a/Dockerfile.builder.linux-aarch64
+++ b/Dockerfile.builder.linux-aarch64
@@ -18,7 +18,7 @@ COPY ./build/artifacts/native-image-source/ /app/build
 
 ENV JAVA_TOOL_OPTIONS='-Djdk.lang.Process.launchMechanism=fork'
 RUN uname -m && ls -lha &&\
-  native-image -Djdk.lang.Process.launchMechanism=fork -J-Djdk.lang.Process.launchMechanism=fork \
+  native-image -H:PageSize=65536 -Djdk.lang.Process.launchMechanism=fork -J-Djdk.lang.Process.launchMechanism=fork \
   -jar dns-proxy-server.jar dns-proxy-server
 
 RUN ls -lhS &&\

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.23.0
+* Build Aarch64 image with page size of 64k to Increase Compatibility #505
+
 ## 3.22.3
 * Fixing graal-sdk dep binary impacts arm, windows, amd static generation
 * Fixed Jar release which was broken when at `3.22.0` depending on the JRE vendor

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.22.3-snapshot
+version=3.23.0-snapshot


### PR DESCRIPTION
Relates to #505 