### PR TITLE
Ensure thread will have names at the logs, behavior changed since `3.25.0` 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,6 @@
+## 3.25.1
+* Ensure thread will have names at the logs, behavior changed since `3.25.0` #436.
+
 ## 3.25.0
 * Optimize resource utilization by using Java Virtual Threads #436.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 ## 3.25.1
-* Ensure thread will have names at the logs, behavior changed since `3.25.0` #436.
+* Ensure thread will have name at the logs, behavior changed since `3.25.0` #436.
 
 ## 3.25.0
 * Optimize resource utilization by using Java Virtual Threads #436.

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation('com.mageddo.commons:commons-lang:0.1.16')
   implementation('org.apache.commons:commons-exec:1.3')
 
-  implementation('ch.qos.logback:logback-classic:1.4.5')
+  implementation('ch.qos.logback:logback-classic:1.5.6')
   implementation('net.java.dev.jna:jna:5.13.0')
   implementation('dnsjava:dnsjava:3.5.2')
   implementation('org.apache.commons:commons-compress:1.22')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.25.0-snapshot
+version=3.25.1-snapshot


### PR DESCRIPTION
Relates to #436