### PR TITLE
Fixing container inspect error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,8 @@ dependencies {
   implementation('dev.failsafe:failsafe:3.3.1')
   implementation("io.github.resilience4j:resilience4j-circuitbreaker:2.2.0")
 
-  implementation('com.github.docker-java:docker-java-core:3.3.4')
-  implementation('com.github.docker-java:docker-java-transport-httpclient5:3.3.4')
+  implementation('com.github.docker-java:docker-java-core:3.4.0')
+  implementation('com.github.docker-java:docker-java-transport-httpclient5:3.4.0')
 
   implementation('info.picocli:picocli:4.7.6')
   implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1')

--- a/src/main/java/com/mageddo/dnsproxyserver/docker/dataprovider/ContainerFacade.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/docker/dataprovider/ContainerFacade.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Container;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ContainerFacade {
 
@@ -11,5 +12,5 @@ public interface ContainerFacade {
 
   List<Container> findActiveContainers();
 
-  InspectContainerResponse inspect(String id);
+  Optional<InspectContainerResponse> inspect(String id);
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/docker/dataprovider/ContainerFacadeDefault.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/docker/dataprovider/ContainerFacadeDefault.java
@@ -2,6 +2,7 @@ package com.mageddo.dnsproxyserver.docker.dataprovider;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
 import com.mageddo.dnsproxyserver.docker.application.Containers;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Default
@@ -44,7 +46,15 @@ public class ContainerFacadeDefault implements ContainerFacade {
   }
 
   @Override
-  public InspectContainerResponse inspect(String id) {
-    return this.dockerClient.inspectContainerCmd(id).exec();
+  public Optional<InspectContainerResponse> inspect(String id) {
+    try {
+      return Optional.of(this.dockerClient.inspectContainerCmd(id).exec());
+    } catch (NotFoundException e) {
+      log.warn("status=container-not-found, action=inspect-container, containerId={}", id);
+    } catch (Exception e) {
+      log.warn("status=unexpected-exception, action=inspect-container, containerId={}, msg={}", id, e.getMessage(), e);
+    }
+
+    return Optional.empty();
   }
 }

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/ContainerDAODefault.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/ContainerDAODefault.java
@@ -28,7 +28,7 @@ public class ContainerDAODefault implements ContainerDAO {
   public List<Container> findActiveContainersMatching(HostnameQuery query) {
     return this.containerFacade.findActiveContainers()
       .stream()
-      .map(it -> this.containerFacade.inspect(it.getId()))
+      .flatMap(it -> this.containerFacade.inspect(it.getId()).stream())
       .filter(ContainerHostnameMatcher.buildPredicate(query))
       .map(ContainerMapper::of)
       .toList();

--- a/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DpsContainerDAODefault.java
+++ b/src/main/java/com/mageddo/dnsproxyserver/solver/docker/dataprovider/DpsContainerDAODefault.java
@@ -55,7 +55,7 @@ public class DpsContainerDAODefault implements DpsContainerDAO {
     return containers
       .stream()
       .findFirst()
-      .map(it -> this.containerFacade.inspect(it.getId()))
+      .flatMap(it -> this.containerFacade.inspect(it.getId()))
       .map(ContainerMapper::of)
       .orElse(null);
   }

--- a/src/test/java/com/mageddo/dnsproxyserver/docker/ContainerFacadeDefaultTest.java
+++ b/src/test/java/com/mageddo/dnsproxyserver/docker/ContainerFacadeDefaultTest.java
@@ -1,0 +1,152 @@
+package com.mageddo.dnsproxyserver.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Container;
+import com.mageddo.dnsproxyserver.docker.dataprovider.ContainerFacadeDefault;
+import testing.templates.docker.ContainerTemplates;
+import testing.templates.docker.DockerClientTemplates;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import testing.templates.docker.InspectContainerResponseTemplates;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class ContainerFacadeDefaultTest {
+
+  ContainerFacadeDefault dao;
+
+  DockerClient dockerClient;
+
+  @BeforeEach
+  void before(){
+    this.dockerClient = DockerClientTemplates.buildSpy();
+    this.dao = new ContainerFacadeDefault(this.dockerClient);
+  }
+
+  @Test
+  void mustFindContainerById(){
+    // arrange
+    final var mockReturn = new ArrayList<Container>();
+    mockReturn.add(ContainerTemplates.buildDpsContainer());
+    mockReturn.add(ContainerTemplates.buildRegularContainerCoffeeMakerCheckout());
+
+    final var containerId = mockReturn.get(0).getId();
+
+    final var inspectContainerCmd = this.dockerClient.listContainersCmd();
+    doReturn(mockReturn)
+      .when(inspectContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var container = this.dao.findById(containerId);
+
+    // assert
+    assertEquals(mockReturn.get(0), container);
+  }
+
+  @Test
+  void mustReturnNullWhenFindContainerByIdNotFound(){
+    // arrange
+    final var mockReturn = new ArrayList<Container>();
+
+    final var containerId = "abc123";
+
+    final var listContainerCmd = this.dockerClient.listContainersCmd();
+    doReturn(mockReturn)
+      .when(listContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var container = this.dao.findById(containerId);
+
+    // assert
+    assertNull(container);
+  }
+
+  @Test
+  void mustListActiveContainers(){
+    // arrange
+    final var expected = new ArrayList<Container>();
+    expected.add(ContainerTemplates.buildRegularContainerCoffeeMakerCheckout());
+
+    final var listContainerCmd = this.dockerClient.listContainersCmd();
+    doReturn(expected)
+      .when(listContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var findActiveContainersResponse = this.dao.findActiveContainers();
+
+    // assert
+    assertEquals(expected, findActiveContainersResponse);
+  }
+
+  @Test
+  void mustInspectContainerById(){
+    // arrange
+    final var expected = InspectContainerResponseTemplates.ngixWithDefaultBridgeNetworkOnly();
+    final var containerId = expected.getId();
+
+    final var inspectContainerCmd = this.dockerClient.inspectContainerCmd(containerId);
+    doReturn(expected)
+      .when(inspectContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var inspectResponse = this.dao.inspect(containerId).orElseThrow();
+
+    // assert
+    assertEquals(expected, inspectResponse);
+  }
+
+  @Test
+  void mustNotThrowErrorWhenInspectContainerNotFound(){
+    // arrange
+    final var containerId = "a39bba9a8bab2899";
+
+    final var inspectContainerCmd = this.dockerClient.inspectContainerCmd(containerId);
+    doThrow(new NotFoundException("Container not found"))
+      .when(inspectContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var container = this.dao.inspect(containerId);
+
+    // assert
+    assertEquals(Optional.empty(), container);
+  }
+
+  @Test
+  void mustNotThrowErrorWhenInspectContainerFails(){
+    // arrange
+    final var containerId = "a39bba9a8bab28aa";
+
+    final var inspectContainerCmd = this.dockerClient.inspectContainerCmd(containerId);
+    doThrow(new NullPointerException("Unexpected failure"))
+      .when(inspectContainerCmd)
+      .exec()
+    ;
+
+    // act
+    final var container = this.dao.inspect(containerId);
+
+    // assert
+    assertEquals(Optional.empty(), container);
+  }
+}


### PR DESCRIPTION
Been playing around with DPS recently, and came across a bug in `docker-java` ([here](https://github.com/docker-java/docker-java/issues/2365)).

If a container is configured with `CAP_ADD` or `CAP_DROP` in lowercase, DPS fails with a nasty exception (seen below).

While waiting for `docker-java` to fix this bug, I figured it would be good if we add some defensive coding here on this side, so it won't fail all DNS lookups if there's a single bad container.

Let me know what you think!

```
17:56:16.572 [virtual-186646 ] WAR c.m.d.server.dns.RequestHandlerDefault            l=101  m=solveAndSummarizeHandlingError  status=solverFailed, currentSolverTime=12, totalTime=12, solver=SolverDocker, query=query=A:zoneminder.dj-server.lan, eClass=RuntimeException, msg=com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.github.dockerjava.api.model.Capability` from String "net_raw": not one of the values accepted for Enum class: [ALL, SYS_BOOT, DAC_OVERRIDE, NET_RAW, BLOCK_SUSPEND, FOWNER, IPC_LOCK, IPC_OWNER, SYS_PACCT, NET_BIND_SERVICE, WAKE_ALARM, FSETID, DAC_READ_SEARCH, SYS_CHROOT, AUDIT_READ, SYS_RAWIO, SYS_ADMIN, KILL, MAC_ADMIN, SYS_RESOURCE, CHOWN, PERFMON, SETPCAP, SYS_PTRACE, NET_ADMIN, SETFCAP, SYS_NICE, LINUX_IMMUTABLE, BPF, AUDIT_CONTROL, LEASE, AUDIT_WRITE, SYS_MODULE, MKNOD, SYSLOG, MAC_OVERRIDE, SYS_TIME, SETGID, SETUID, CHECKPOINT_RESTORE, SYS_TTY_CONFIG, NET_BROADCAST]
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: com.github.dockerjava.api.command.InspectContainerResponse["HostConfig"]->com.github.dockerjava.api.model.HostConfig["CapDrop"]->java.lang.Object[][0])
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.github.dockerjava.api.model.Capability` from String "net_raw": not one of the values accepted for Enum class: [ALL, SYS_BOOT, DAC_OVERRIDE, NET_RAW, BLOCK_SUSPEND, FOWNER, IPC_LOCK, IPC_OWNER, SYS_PACCT, NET_BIND_SERVICE, WAKE_ALARM, FSETID, DAC_READ_SEARCH, SYS_CHROOT, AUDIT_READ, SYS_RAWIO, SYS_ADMIN, KILL, MAC_ADMIN, SYS_RESOURCE, CHOWN, PERFMON, SETPCAP, SYS_PTRACE, NET_ADMIN, SETFCAP, SYS_NICE, LINUX_IMMUTABLE, BPF, AUDIT_CONTROL, LEASE, AUDIT_WRITE, SYS_MODULE, MKNOD, SYSLOG, MAC_OVERRIDE, SYS_TIME, SETGID, SETUID, CHECKPOINT_RESTORE, SYS_TTY_CONFIG, NET_BROADCAST]
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: com.github.dockerjava.api.command.InspectContainerResponse["HostConfig"]->com.github.dockerjava.api.model.HostConfig["CapDrop"]->java.lang.Object[][0])
	at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:77)
	at com.github.dockerjava.core.exec.InspectContainerCmdExec.execute(InspectContainerCmdExec.java:31)
	at com.github.dockerjava.core.exec.InspectContainerCmdExec.execute(InspectContainerCmdExec.java:13)
	at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
	at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:33)
	at com.github.dockerjava.core.command.InspectContainerCmdImpl.exec(InspectContainerCmdImpl.java:51)
	at com.mageddo.dnsproxyserver.docker.dataprovider.ContainerFacadeDefault.inspect(ContainerFacadeDefault.java:48)
	at com.mageddo.dnsproxyserver.solver.docker.dataprovider.ContainerDAODefault.lambda$findActiveContainersMatching$0(ContainerDAODefault.java:31)
	at java.base@21.0.2/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base@21.0.2/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base@21.0.2/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base@21.0.2/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base@21.0.2/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base@21.0.2/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base@21.0.2/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base@21.0.2/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base@21.0.2/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at com.mageddo.dnsproxyserver.solver.docker.dataprovider.ContainerDAODefault.findActiveContainersMatching(ContainerDAODefault.java:34)
	at com.mageddo.dnsproxyserver.solver.docker.application.ContainerSolvingService.findBestMatch(ContainerSolvingService.java:39)
	at com.mageddo.dnsproxyserver.solver.SolverDocker.lambda$handle$0(SolverDocker.java:40)
	at com.mageddo.dnsproxyserver.solver.HostnameMatcher.match(HostnameMatcher.java:22)
	at com.mageddo.dnsproxyserver.solver.SolverDocker.handle(SolverDocker.java:39)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveAndSummarize(RequestHandlerDefault.java:115)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveAndSummarizeHandlingError(RequestHandlerDefault.java:99)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solve(RequestHandlerDefault.java:82)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveFixingCacheTTL(RequestHandlerDefault.java:73)
	at com.mageddo.dnsproxyserver.solver.SolverCache.calculateValueWithoutLocks(SolverCache.java:70)
	at com.mageddo.dnsproxyserver.solver.SolverCache.handleRes(SolverCache.java:51)
	at com.mageddo.dnsproxyserver.solver.SolverCache.handle(SolverCache.java:40)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveCaching(RequestHandlerDefault.java:66)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.handle(RequestHandlerDefault.java:54)
	at com.mageddo.dnsserver.UDPServer.handle(UDPServer.java:55)
	at com.mageddo.dnsserver.UDPServer.lambda$start0$0(UDPServer.java:43)
	at java.base@21.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base@21.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.2/java.lang.VirtualThread.run(VirtualThread.java:309)
	at java.base@21.0.2/java.lang.VirtualThread$VThreadContinuation$1.run(VirtualThread.java:190)
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.github.dockerjava.api.model.Capability` from String "net_raw": not one of the values accepted for Enum class: [ALL, SYS_BOOT, DAC_OVERRIDE, NET_RAW, BLOCK_SUSPEND, FOWNER, IPC_LOCK, IPC_OWNER, SYS_PACCT, NET_BIND_SERVICE, WAKE_ALARM, FSETID, DAC_READ_SEARCH, SYS_CHROOT, AUDIT_READ, SYS_RAWIO, SYS_ADMIN, KILL, MAC_ADMIN, SYS_RESOURCE, CHOWN, PERFMON, SETPCAP, SYS_PTRACE, NET_ADMIN, SETFCAP, SYS_NICE, LINUX_IMMUTABLE, BPF, AUDIT_CONTROL, LEASE, AUDIT_WRITE, SYS_MODULE, MKNOD, SYSLOG, MAC_OVERRIDE, SYS_TIME, SETGID, SETUID, CHECKPOINT_RESTORE, SYS_TTY_CONFIG, NET_BROADCAST]
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: com.github.dockerjava.api.command.InspectContainerResponse["HostConfig"]->com.github.dockerjava.api.model.HostConfig["CapDrop"]->java.lang.Object[][0])
	at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1958)
	at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:1245)
	at com.fasterxml.jackson.databind.deser.std.EnumDeserializer._deserializeAltString(EnumDeserializer.java:447)
	at com.fasterxml.jackson.databind.deser.std.EnumDeserializer._fromString(EnumDeserializer.java:304)
	at com.fasterxml.jackson.databind.deser.std.EnumDeserializer.deserialize(EnumDeserializer.java:273)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:218)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4881)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3035)
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:3499)
	at com.github.dockerjava.core.DockerObjectDeserializer.deserialize(DockerClientConfig.java:132)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4905)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3893)
	at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:75)
	... 37 common frames omitted
17:56:16.572 [virtual-186646 ] WAR c.m.d.server.dns.RequestHandlerDefault            l=56   m=handle                          status=solverFailed, totalTime=13, eClass=NullPointerException, msg=null
java.lang.NullPointerException: null
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solve(RequestHandlerDefault.java:83)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveFixingCacheTTL(RequestHandlerDefault.java:73)
	at com.mageddo.dnsproxyserver.solver.SolverCache.calculateValueWithoutLocks(SolverCache.java:70)
	at com.mageddo.dnsproxyserver.solver.SolverCache.handleRes(SolverCache.java:51)
	at com.mageddo.dnsproxyserver.solver.SolverCache.handle(SolverCache.java:40)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.solveCaching(RequestHandlerDefault.java:66)
	at com.mageddo.dnsproxyserver.server.dns.RequestHandlerDefault.handle(RequestHandlerDefault.java:54)
	at com.mageddo.dnsserver.UDPServer.handle(UDPServer.java:55)
	at com.mageddo.dnsserver.UDPServer.lambda$start0$0(UDPServer.java:43)
	at java.base@21.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base@21.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.2/java.lang.VirtualThread.run(VirtualThread.java:309)
	at java.base@21.0.2/java.lang.VirtualThread$VThreadContinuation$1.run(VirtualThread.java:190)
```

